### PR TITLE
Check for file/directory before creating cache dependency

### DIFF
--- a/EmbeddedResourceVirtualPathProvider/Vpp.cs
+++ b/EmbeddedResourceVirtualPathProvider/Vpp.cs
@@ -93,7 +93,12 @@ namespace EmbeddedResourceVirtualPathProvider
                 return resource.GetCacheDependency(utcStart);
             }
 
-            return base.GetCacheDependency(virtualPath, virtualPathDependencies, utcStart);
+            if (DirectoryExists(virtualPath) || FileExists(virtualPath))
+            {
+                return base.GetCacheDependency(virtualPath, virtualPathDependencies, utcStart);
+            }
+
+            return null;
         }
 
         private bool ShouldUsePrevious(string virtualPath, EmbeddedResource resource)


### PR DESCRIPTION
When checking the VPP for resources that are handled by other virtual providers, GetCacheDependency throws HttpException with "Directory '[virtual path]' does not exist. Failed to start monitoring file changes." This change verifies that the resource exists to create a dependency on.

This is an alternate patch for the same issue as pull request https://github.com/mcintyre321/EmbeddedResourceVirtualPathProvider/pull/2
