### PR TITLE
Added ability to set cache control header max-age and cacheability

### DIFF
--- a/EmbeddedResourceVirtualPathProvider/EmbeddedResourceCacheControl.cs
+++ b/EmbeddedResourceVirtualPathProvider/EmbeddedResourceCacheControl.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace EmbeddedResourceVirtualPathProvider
+{
+    public class EmbeddedResourceCacheControl
+    {
+        public int MaxAge;
+        public HttpCacheability Cacheability;
+    }
+}

--- a/EmbeddedResourceVirtualPathProvider/EmbeddedResourceVirtualFile.cs
+++ b/EmbeddedResourceVirtualPathProvider/EmbeddedResourceVirtualFile.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Web;
 using System.Web.Hosting;
 
 namespace EmbeddedResourceVirtualPathProvider
@@ -6,15 +7,22 @@ namespace EmbeddedResourceVirtualPathProvider
     class EmbeddedResourceVirtualFile : VirtualFile
     {
         readonly EmbeddedResource embedded;
+        readonly EmbeddedResourceCacheControl cacheControl;
 
-        public EmbeddedResourceVirtualFile(string virtualPath, EmbeddedResource embedded)
+        public EmbeddedResourceVirtualFile(string virtualPath, EmbeddedResource embedded, EmbeddedResourceCacheControl cacheControl)
             : base(virtualPath)
         {
             this.embedded = embedded;
+            this.cacheControl = cacheControl;
         }
 
         public override Stream Open()
         {
+            if (cacheControl != null)
+            {
+                HttpContext.Current.Response.Cache.SetCacheability(cacheControl.Cacheability);
+                HttpContext.Current.Response.Cache.AppendCacheExtension("max-age=" + cacheControl.MaxAge);
+            }
             return embedded.GetStream();
         }
     }

--- a/EmbeddedResourceVirtualPathProvider/EmbeddedResourceVirtualPathProvider.csproj
+++ b/EmbeddedResourceVirtualPathProvider/EmbeddedResourceVirtualPathProvider.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EmbeddedResource.cs" />
+    <Compile Include="EmbeddedResourceCacheControl.cs" />
     <Compile Include="EmbeddedResourceVirtualFile.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="Vpp.cs" />

--- a/EmbeddedResourceVirtualPathProvider/Vpp.cs
+++ b/EmbeddedResourceVirtualPathProvider/Vpp.cs
@@ -18,10 +18,12 @@ namespace EmbeddedResourceVirtualPathProvider
             Array.ForEach(assemblies, a => Add(a));
             UseResource = er => true;
             UseLocalIfAvailable = resource => true;
+            CacheControl = er => null;
         }
 
         public Func<EmbeddedResource, bool> UseResource { get; set; }
         public Func<EmbeddedResource, bool> UseLocalIfAvailable { get; set; }
+        public Func<EmbeddedResource, EmbeddedResourceCacheControl> CacheControl { get; set; } 
 
         public void Add(Assembly assembly, string projectSourcePath = null)
         {
@@ -45,7 +47,7 @@ namespace EmbeddedResourceVirtualPathProvider
             //if (base.FileExists(virtualPath)) return base.GetFile(virtualPath);
             var resource = GetResourceFromVirtualPath(virtualPath);
             if (resource != null)
-                return new EmbeddedResourceVirtualFile(virtualPath, resource);
+                return new EmbeddedResourceVirtualFile(virtualPath, resource, CacheControl(resource));
             return base.GetFile(virtualPath);
         }
 


### PR DESCRIPTION
This change uses a callback function similar to UseResource or UseLocalIfAvailable, easily allowing either global or per-resource settings.

This is in regards to issue https://github.com/mcintyre321/EmbeddedResourceVirtualPathProvider/issues/9

Let me know if you have any problems with it.  It maintains the default behaviour of no caching while allowing a developer to set custom cache behaviour on a global or a per-resource simply by changing the new CacheControl callback.
