### PR TITLE
Added support for a physical file to have virtual cache dependencies

### DIFF
--- a/EmbeddedResourceVirtualPathProvider/Vpp.cs
+++ b/EmbeddedResourceVirtualPathProvider/Vpp.cs
@@ -103,6 +103,18 @@ namespace EmbeddedResourceVirtualPathProvider
                 return resource.GetCacheDependency(utcStart);
             }
 
+            var virtualDependencies = virtualPathDependencies.OfType<string>()
+                .Select(x => new {path = x, resource = GetResourceFromVirtualPath(x)})
+                .Where(x => x.resource != null)
+                .ToList();
+
+            if (virtualDependencies.Any())
+            {
+                virtualPathDependencies = virtualDependencies.OfType<string>()
+                    .Except(virtualDependencies.Select(v => v.path))
+                    .Concat(virtualDependencies.Select(v => $"/bin/{v.resource.AssemblyName}").Distinct());
+            }
+
             if (DirectoryExists(virtualPath) || FileExists(virtualPath))
             {
                 return base.GetCacheDependency(virtualPath, virtualPathDependencies, utcStart);


### PR DESCRIPTION
I ran into trouble when a physical file had virtual files as cache dependencies.
This code change replaces any virtual file dependency paths to the virtual file's assembly in the /bin-folder.